### PR TITLE
Fix GitHub repository information to correct URL.

### DIFF
--- a/adafruit_gc_iot_core.py
+++ b/adafruit_gc_iot_core.py
@@ -43,7 +43,7 @@ from adafruit_jwt import JWT
 import adafruit_ntp as NTP
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Cloud_IOT_Core.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_GC_IOT_Core.git"
 
 class MQTT_API_ERROR(Exception):
     """Exception raised on MQTT API return-code errors."""


### PR DESCRIPTION
What the title says. This is needed so the upcoming `circup` utility can work correctly (see https://github.com/ntoll/circup).

Please don't hesitate to ask me questions if need be. Thank you..!

cc/@ladyada