### PR TITLE
Update for minimqtt PR

### DIFF
--- a/adafruit_gc_iot_core.py
+++ b/adafruit_gc_iot_core.py
@@ -339,7 +339,7 @@ class Cloud_Core:
         self._reg_id = secrets["registry_id"]
         self._device_id = secrets["device_id"]
         self._private_key = secrets["private_key"]
-        self.broker = "mqtt.googleapis.com"
+        self.broker = "https://mqtt.googleapis.com"
         self.username = b"unused"
         self.cid = self.client_id
 

--- a/adafruit_gc_iot_core.py
+++ b/adafruit_gc_iot_core.py
@@ -128,6 +128,14 @@ class MQTT_API:
         # De-initialize MiniMQTT Client
         self._client.deinit()
 
+    def reconnect(self):
+        """Reconnects to the Google MQTT Broker.
+        """
+        try:
+            self._client.reconnect()
+        except:
+            raise MQTT_API_ERROR("Error reconnecting to Google MQTT.")
+
     def connect(self):
         """Connects to the Google MQTT Broker.
         """

--- a/examples/gc_iot_core_simpletest.py
+++ b/examples/gc_iot_core_simpletest.py
@@ -6,7 +6,7 @@ from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
-from adafruit_minimqtt import MQTT
+import adafruit_minimqtt as MQTT
 from adafruit_gc_iot_core import Cloud_Core, MQTT_API
 
 ### WiFi ###
@@ -92,6 +92,9 @@ print("Connecting to WiFi...")
 wifi.connect()
 print("Connected!")
 
+# Initialize MQTT interface with the esp interface
+MQTT.set_socket(socket, esp)
+
 # Initialize Google Cloud IoT Core interface
 google_iot = Cloud_Core(esp, secrets)
 
@@ -101,14 +104,10 @@ google_iot = Cloud_Core(esp, secrets)
 # print("Your JWT is: ", jwt)
 
 # Set up a new MiniMQTT Client
-client = MQTT(
-    socket,
-    broker=google_iot.broker,
-    username=google_iot.username,
-    password=secrets["jwt"],
-    client_id=google_iot.cid,
-    network_manager=wifi,
-)
+client = MQTT.MQTT(broker=google_iot.broker,
+                   username=google_iot.username,
+                   password=secrets["jwt"],
+                   client_id=google_iot.cid)
 
 # Initialize Google MQTT API Client
 google_mqtt = MQTT_API(client)

--- a/examples/gc_iot_core_simpletest.py
+++ b/examples/gc_iot_core_simpletest.py
@@ -128,5 +128,15 @@ google_mqtt.connect()
 # while True:
 #    google_mqtt.loop()
 
-# Attempt to loop forever and handle network disconnection
-google_mqtt.loop_blocking()
+# Start a blocking message loop...
+# NOTE: NO code below this loop will execute
+# NOTE: Network reconnection is handled within this loop
+while True:
+    try:
+        google_mqtt.loop()
+    except (ValueError, RuntimeError) as e:
+        print("Failed to get data, retrying\n", e)
+        wifi.reset()
+        google_mqtt.reconnect()
+        continue
+    time.sleep(1)

--- a/examples/gc_iot_core_simpletest.py
+++ b/examples/gc_iot_core_simpletest.py
@@ -1,3 +1,4 @@
+import time
 import board
 import busio
 from digitalio import DigitalInOut


### PR DESCRIPTION
This pull request updates the simpletest for compatibility with breaking PR adafruit/Adafruit_CircuitPython_MiniMQTT#21

* Adds `reconnect()` method
* Updates URL to HTTP**S**

Following resource(s) will need to be updated as well:

- [x] [GCP IoT Planter](https://github.com/adafruit/Adafruit_Learning_System_Guides/blob/master/PyPortal_GCP_IOT_Planter/code.py)