### PR TITLE
Add StreamHandler to logger, add missing dependencies

### DIFF
--- a/adafruit_gc_iot_core.py
+++ b/adafruit_gc_iot_core.py
@@ -315,6 +315,7 @@ class Cloud_Core:
         self.logger = None
         if log is True:
             self.logger = logging.getLogger("log")
+            self.logger.addHandler(logging.StreamHandler())
             self.logger.setLevel(logging.DEBUG)
         # Configuration, from secrets file
         self._proj_id = secrets["project_id"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
-adafruit_jwt
-adafruit_logging>=4.0.1
+adafruit-circuitpython-jwt
+adafruit-circuitpython-logging>=4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+adafruit_jwt
+adafruit_logging>=4.0.1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,11 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka", "adafruit_jwt", "adafruit_logging>=4.0.1"],
+    install_requires=[
+        "Adafruit-Blinka",
+        "adafruit-circuitpython-jwt",
+        "adafruit-circuitpython-logging>=4.0.1",
+    ],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,11 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka"],
+    install_requires=[
+        "Adafruit-Blinka",
+        "adafruit_jwt",
+        "adafruit_logging>=4.0.1"
+    ],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=[
-        "Adafruit-Blinka",
-        "adafruit_jwt",
-        "adafruit_logging>=4.0.1"
-    ],
+    install_requires=["Adafruit-Blinka", "adafruit_jwt", "adafruit_logging>=4.0.1"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Resolves #24 by adding a `StreamHandler` to the `Logger`, and pins the minimum version of `adafruit_logging`.  Also adds missing dependencies